### PR TITLE
Use https url to git repository in cabal file

### DIFF
--- a/xhtml.cabal
+++ b/xhtml.cabal
@@ -18,7 +18,7 @@ Cabal-version:      >= 1.6
 
 Source-repository head
     type:           git
-    location:       git@github.com:haskell/xhtml.git
+    location:       https://github.com/haskell/xhtml
 
 library 
     Build-depends:  base >= 4.0 && < 4.6


### PR DESCRIPTION
This way it gets hyperlinked on Hackage, and still works with `git
clone`.
