### PR TITLE
Avoid `Data.List.{head,tail}`

### DIFF
--- a/Text/XHtml/Debug.hs
+++ b/Text/XHtml/Debug.hs
@@ -10,6 +10,8 @@ import Text.XHtml.Table
 import Text.XHtml.Strict.Elements
 import Text.XHtml.Strict.Attributes
 
+import Data.List (uncons)
+
 --
 -- * Tree Displaying Combinators
 --
@@ -51,7 +53,7 @@ treeHtml colors h = table ! [
         where
               -- This stops a column of colors being the same
               -- color as the immediately outside nesting bar.
-              morecolors = filter ((/= c).head) (manycolors cs)
+              morecolors = filter (maybe True ((/= c) . fst) . uncons) (manycolors cs)
               bar = td ! [bgcolor' c,width "10"] << spaceHtml
               hd = td ! [bgcolor' c] << hopen
               tl = td ! [bgcolor' c] << hclose


### PR DESCRIPTION
CLC has approved the proposal to add `{-# WARNING #-}` to `Data.List.{head,tail}` (https://github.com/haskell/core-libraries-committee/issues/87). It means that usage of `head` and `tail` will emit compile-time warnings.

This patch eliminates the only usage of `head` in `xhtml`.