### PR TITLE
Use `Builder` instead of `String`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 3000.3
+
+- The internal representation has changed from `String` and `[String]` to a
+  `Data.ByteString.Builder` and difference lists. [#18](https://github.com/haskell/xhtml/pull/18)
+
 ## 3000.2.2.1
 
 - Special release which supports *only* `base >= 4.11`

--- a/Text/XHtml/Debug.hs
+++ b/Text/XHtml/Debug.hs
@@ -86,7 +86,7 @@ debugHtml obj = table ! [border 0] <<
   where
 
       debug' :: Html -> [HtmlTree]
-      debug' (Html markups) = map debug markups
+      debug' (Html markups) = map debug (markups [])
 
       debug :: HtmlElement -> HtmlTree
       debug (HtmlString str) = HtmlLeaf (spaceHtml +++

--- a/Text/XHtml/Debug.hs
+++ b/Text/XHtml/Debug.hs
@@ -11,6 +11,7 @@ import Text.XHtml.Extras
 import Text.XHtml.Table
 import Text.XHtml.Strict.Elements
 import Text.XHtml.Strict.Attributes
+import Data.Foldable (toList)
 
 import Data.List (uncons)
 
@@ -85,8 +86,8 @@ debugHtml obj = table ! [border 0] <<
               )
   where
 
-      debug' :: Html -> [HtmlTree]
-      debug' (Html markups) = map debug (markups [])
+      debug' :: Html -> Seq HtmlTree
+      debug' (Html markups) = fmap debug markups
 
       debug :: HtmlElement -> HtmlTree
       debug (HtmlString str) = HtmlLeaf (spaceHtml +++
@@ -98,7 +99,7 @@ debugHtml obj = table ! [border 0] <<
               }) =
               if isNoHtml content'
                 then HtmlNode hd [] noHtml
-                else HtmlNode hd (map debug (getHtmlElements content')) tl
+                else HtmlNode hd (toList $ fmap debug (getHtmlElements content')) tl
         where
               attrs = mkAttrs []
               args = if null attrs

--- a/Text/XHtml/Debug.hs
+++ b/Text/XHtml/Debug.hs
@@ -11,7 +11,6 @@ import Text.XHtml.Extras
 import Text.XHtml.Table
 import Text.XHtml.Strict.Elements
 import Text.XHtml.Strict.Attributes
-import Data.Foldable (toList)
 
 import Data.List (uncons)
 
@@ -86,8 +85,8 @@ debugHtml obj = table ! [border 0] <<
               )
   where
 
-      debug' :: Html -> Seq HtmlTree
-      debug' (Html markups) = fmap debug markups
+      debug' :: Html -> [HtmlTree]
+      debug' (Html markups) = map debug (markups [])
 
       debug :: HtmlElement -> HtmlTree
       debug (HtmlString str) = HtmlLeaf (spaceHtml +++
@@ -99,7 +98,7 @@ debugHtml obj = table ! [border 0] <<
               }) =
               if isNoHtml content'
                 then HtmlNode hd [] noHtml
-                else HtmlNode hd (toList $ fmap debug (getHtmlElements content')) tl
+                else HtmlNode hd (map debug (getHtmlElements content')) tl
         where
               attrs = mkAttrs []
               args = if null attrs

--- a/Text/XHtml/Debug.hs
+++ b/Text/XHtml/Debug.hs
@@ -86,7 +86,7 @@ debugHtml obj = table ! [border 0] <<
   where
 
       debug' :: Html -> [HtmlTree]
-      debug' (Html markups) = map debug (markups [])
+      debug' (Html markups) = map debug markups
 
       debug :: HtmlElement -> HtmlTree
       debug (HtmlString str) = HtmlLeaf (spaceHtml +++

--- a/Text/XHtml/Debug.hs
+++ b/Text/XHtml/Debug.hs
@@ -1,5 +1,7 @@
 {-# OPTIONS_HADDOCK hide #-}
 
+{-# language OverloadedStrings #-}
+
 -- | This module contains functions for displaying
 --   HTML as a pretty tree.
 module Text.XHtml.Debug ( HtmlTree(..), treeHtml, treeColors, debugHtml ) where
@@ -36,13 +38,13 @@ treeHtml colors h = table ! [
 
       treeHtml' :: [String] -> HtmlTree -> HtmlTable
       treeHtml' _ (HtmlLeaf leaf) = cell
-                                         (td ! [width "100%"] 
-                                            << bold  
+                                         (td ! [width "100%"]
+                                            << bold
                                                << leaf)
       treeHtml' (c:cs@(c2:_)) (HtmlNode hopen ts hclose) =
           if null ts && isNoHtml hclose
           then
-              cell hd 
+              cell hd
           else if null ts
           then
               hd </> bar `beside` (td ! [bgcolor' c2] << spaceHtml)
@@ -67,7 +69,7 @@ treeColors :: [String]
 treeColors = ["#88ccff","#ffffaa","#ffaaff","#ccffff"] ++ treeColors
 
 
--- 
+--
 -- * Html Debugging Combinators
 --
 
@@ -75,10 +77,10 @@ treeColors = ["#88ccff","#ffffaa","#ffaaff","#ccffff"] ++ treeColors
 -- Html as a tree structure, allowing debugging of what is
 -- actually getting produced.
 debugHtml :: (HTML a) => a -> Html
-debugHtml obj = table ! [border 0] << 
+debugHtml obj = table ! [border 0] <<
                   ( th ! [bgcolor' "#008888"]
                      << underline'
-                       << "Debugging Output"
+                       << ("Debugging Output" :: String)
                </>  td << (toHtml (debug' (toHtml obj)))
               )
   where
@@ -88,7 +90,7 @@ debugHtml obj = table ! [border 0] <<
 
       debug :: HtmlElement -> HtmlTree
       debug (HtmlString str) = HtmlLeaf (spaceHtml +++
-                                              linesToHtml (lines str))
+                                              linesToHtml (lines (builderToString str)))
       debug (HtmlTag {
               markupTag = tag',
               markupContent = content',
@@ -100,9 +102,9 @@ debugHtml obj = table ! [border 0] <<
         where
               args = if null attrs
                      then ""
-                     else "  " ++ unwords (map show attrs)
-              hd = xsmallFont << ("<" ++ tag' ++ args ++ ">")
-              tl = xsmallFont << ("</" ++ tag' ++ ">")
+                     else "  " <> (unwords (map show attrs))
+              hd = xsmallFont << ("<" <> builderToString tag' <> args <> ">")
+              tl = xsmallFont << ("</" <> builderToString tag' <> ">")
 
 bgcolor' :: String -> HtmlAttr
 bgcolor' c = thestyle ("background-color:" ++ c)

--- a/Text/XHtml/Debug.hs
+++ b/Text/XHtml/Debug.hs
@@ -86,7 +86,7 @@ debugHtml obj = table ! [border 0] <<
   where
 
       debug' :: Html -> [HtmlTree]
-      debug' (Html markups _) = map debug (markups [])
+      debug' (Html markups) = map debug (markups [])
 
       debug :: HtmlElement -> HtmlTree
       debug (HtmlString str) = HtmlLeaf (spaceHtml +++

--- a/Text/XHtml/Debug.hs
+++ b/Text/XHtml/Debug.hs
@@ -86,7 +86,7 @@ debugHtml obj = table ! [border 0] <<
   where
 
       debug' :: Html -> [HtmlTree]
-      debug' (Html markups) = map debug markups
+      debug' (Html markups) = map debug (markups [])
 
       debug :: HtmlElement -> HtmlTree
       debug (HtmlString str) = HtmlLeaf (spaceHtml +++
@@ -94,12 +94,13 @@ debugHtml obj = table ! [border 0] <<
       debug (HtmlTag {
               markupTag = tag',
               markupContent = content',
-              markupAttrs  = attrs
+              markupAttrs  = mkAttrs
               }) =
-              case content' of
-                Html [] -> HtmlNode hd [] noHtml
-                Html xs -> HtmlNode hd (map debug xs) tl
+              if isNoHtml content'
+                then HtmlNode hd [] noHtml
+                else HtmlNode hd (map debug (getHtmlElements content')) tl
         where
+              attrs = mkAttrs []
               args = if null attrs
                      then ""
                      else "  " <> (unwords (map show attrs))

--- a/Text/XHtml/Debug.hs
+++ b/Text/XHtml/Debug.hs
@@ -86,7 +86,7 @@ debugHtml obj = table ! [border 0] <<
   where
 
       debug' :: Html -> [HtmlTree]
-      debug' (Html markups) = map debug (markups [])
+      debug' (Html markups _) = map debug (markups [])
 
       debug :: HtmlElement -> HtmlTree
       debug (HtmlString str) = HtmlLeaf (spaceHtml +++

--- a/Text/XHtml/Extras.hs
+++ b/Text/XHtml/Extras.hs
@@ -11,14 +11,15 @@ import Text.XHtml.Strict.Attributes
 -- | Convert a 'String' to 'Html', converting
 --   characters that need to be escaped to HTML entities.
 stringToHtml :: String -> Html
-stringToHtml = primHtml . stringToHtmlString 
+stringToHtml = primHtml . builderToString . stringToHtmlString
 
 -- | This converts a string, but keeps spaces as non-line-breakable.
 lineToHtml :: String -> Html
-lineToHtml = primHtml . concatMap htmlizeChar2 . stringToHtmlString 
-   where 
-      htmlizeChar2 ' ' = "&nbsp;"
-      htmlizeChar2 c   = [c]
+lineToHtml =
+    primHtmlNonEmptyBuilder . stringToHtmlString . foldMap htmlizeChar2
+  where
+    htmlizeChar2 ' ' = "&nbsp;"
+    htmlizeChar2 c   = [c]
 
 -- | This converts a string, but keeps spaces as non-line-breakable,
 --   and adds line breaks between each of the strings in the input list.
@@ -76,7 +77,7 @@ hotlink url h = HotLink {
       hotLinkAttributes = [] }
 
 
--- 
+--
 -- * Lists
 --
 

--- a/Text/XHtml/Frameset.hs
+++ b/Text/XHtml/Frameset.hs
@@ -1,3 +1,5 @@
+{-# language OverloadedStrings #-}
+
 -- | Produces XHTML 1.0 Frameset.
 module Text.XHtml.Frameset (
      -- * Data types
@@ -5,12 +7,12 @@ module Text.XHtml.Frameset (
      -- * Classes
      HTML(..), ADDATTRS(..), CHANGEATTRS(..),
      -- * Primitives and basic combinators
-     (<<), concatHtml, (+++), 
+     (<<), concatHtml, (+++),
      noHtml, isNoHtml, tag, itag,
      htmlAttrPair, emptyAttr, intAttr, strAttr, htmlAttr,
-     primHtml, 
+     primHtml,
      -- * Rendering
-     showHtml, renderHtml, prettyHtml, 
+     showHtml, renderHtml, prettyHtml,
      showHtmlFragment, renderHtmlFragment, prettyHtmlFragment,
      module Text.XHtml.Strict.Elements,
      module Text.XHtml.Frameset.Elements,
@@ -28,26 +30,26 @@ import Text.XHtml.Frameset.Attributes
 
 import Text.XHtml.Extras
 
-docType :: String
+docType :: Builder
 docType =
-      "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Frameset//EN\"" ++
+      "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Frameset//EN\"" <>
      " \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd\">"
 
 -- | Output the HTML without adding newlines or spaces within the markup.
 --   This should be the most time and space efficient way to
 --   render HTML, though the output is quite unreadable.
-showHtml :: HTML html => html -> String
+showHtml :: HTML html => html -> Builder
 showHtml = showHtmlInternal docType
 
 -- | Outputs indented HTML. Because space matters in
 --   HTML, the output is quite messy.
-renderHtml :: HTML html => html -> String
+renderHtml :: HTML html => html -> Builder
 renderHtml = renderHtmlInternal docType
 
 -- | Outputs indented HTML, with indentation inside elements.
---   This can change the meaning of the HTML document, and 
+--   This can change the meaning of the HTML document, and
 --   is mostly useful for debugging the HTML output.
 --   The implementation is inefficient, and you are normally
 --   better off using 'showHtml' or 'renderHtml'.
 prettyHtml :: HTML html => html -> String
-prettyHtml = prettyHtmlInternal docType
+prettyHtml = prettyHtmlInternal (builderToString docType)

--- a/Text/XHtml/Frameset/Attributes.hs
+++ b/Text/XHtml/Frameset/Attributes.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_HADDOCK hide #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Text.XHtml.Frameset.Attributes where
 

--- a/Text/XHtml/Frameset/Elements.hs
+++ b/Text/XHtml/Frameset/Elements.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_HADDOCK hide #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Text.XHtml.Frameset.Elements where
 

--- a/Text/XHtml/Internals.hs
+++ b/Text/XHtml/Internals.hs
@@ -59,10 +59,10 @@ htmlAttrPair :: HtmlAttr -> (Builder,Builder)
 htmlAttrPair (HtmlAttr n v) = (n,v)
 
 
-newtype Html = Html { unHtml :: [HtmlElement] -> [HtmlElement] }
+newtype Html = Html { unHtml :: [HtmlElement] }
 
 getHtmlElements :: Html -> [HtmlElement]
-getHtmlElements html = unHtml html []
+getHtmlElements html = unHtml html
 
 builderToString :: Builder -> String
 builderToString =
@@ -97,15 +97,15 @@ class HTML a where
       toHtml     :: a -> Html
       toHtmlFromList :: [a] -> Html
 
-      toHtmlFromList xs = Html (foldr (\x acc -> unHtml (toHtml x) . acc) id xs)
+      toHtmlFromList xs = Html (concatMap (unHtml . toHtml) xs)
 
 instance HTML Html where
       toHtml a    = a
 
 instance HTML Char where
       toHtml       a = toHtml [a]
-      toHtmlFromList []  = Html id
-      toHtmlFromList str = Html (HtmlString (stringToHtmlString str) :)
+      toHtmlFromList []  = Html []
+      toHtmlFromList str = Html [HtmlString (stringToHtmlString str)]
 
 instance (HTML a) => HTML [a] where
       toHtml xs = toHtmlFromList xs
@@ -114,8 +114,8 @@ instance HTML a => HTML (Maybe a) where
       toHtml = maybe noHtml toHtml
 
 instance HTML Text where
-    toHtml "" = Html id
-    toHtml xs = Html (HtmlString (textToHtmlString xs) :)
+    toHtml "" = Html []
+    toHtml xs = Html [ HtmlString (textToHtmlString xs) ]
 
 mapDlist :: (a -> b) -> ([a] -> [a]) -> [b] -> [b]
 mapDlist f as = (map f (as []) ++)
@@ -134,7 +134,7 @@ instance (CHANGEATTRS b) => CHANGEATTRS (a -> b) where
       changeAttrs fn f = \ arg -> changeAttrs (fn arg) f
 
 instance ADDATTRS Html where
-    (Html htmls) ! attr = Html (mapDlist addAttrs htmls)
+    (Html htmls) ! attr = Html (map addAttrs htmls)
       where
         addAttrs html =
             case html of
@@ -148,7 +148,7 @@ instance ADDATTRS Html where
 
 
 instance CHANGEATTRS Html where
-      changeAttrs (Html htmls) f = Html (mapDlist addAttrs htmls)
+      changeAttrs (Html htmls) f = Html (map addAttrs htmls)
         where
               addAttrs (html@(HtmlTag { markupAttrs = attrs }) )
                             = html { markupAttrs = (f . attrs) }
@@ -168,22 +168,22 @@ fn << arg = fn (toHtml arg)
 
 
 concatHtml :: (HTML a) => [a] -> Html
-concatHtml = Html . foldr (.) id . map (unHtml . toHtml)
+concatHtml = Html . concatMap (unHtml . toHtml)
 
 -- | Create a piece of HTML which is the concatenation
 --   of two things which can be made into HTML.
 (+++) :: (HTML a, HTML b) => a -> b -> Html
-a +++ b = Html (unHtml (toHtml a) . unHtml (toHtml b))
+a +++ b = Html (unHtml (toHtml a) <> unHtml (toHtml b))
 
 
 -- | An empty piece of HTML.
 noHtml :: Html
-noHtml = Html id
+noHtml = Html []
 
 -- | Checks whether the given piece of HTML is empty. This materializes the
 -- list, so it's not great to do this a bunch.
 isNoHtml :: Html -> Bool
-isNoHtml (Html xs) = null (xs [])
+isNoHtml (Html xs) = null xs
 
 -- | Constructs an element with a custom name.
 tag :: Builder -- ^ Element name
@@ -191,14 +191,12 @@ tag :: Builder -- ^ Element name
     -> Html
 tag str htmls =
     Html
-        (
-        HtmlTag
-            { markupTag = str
-            , markupAttrs = id
-            , markupContent = htmls
-            }
-        :
-        )
+    [ HtmlTag
+        { markupTag = str
+        , markupAttrs = id
+        , markupContent = htmls
+        }
+    ]
 
 -- | Constructs an element with a custom name, and
 --   without any children.
@@ -249,12 +247,12 @@ textToHtmlString = Text.foldr (\c acc -> fixChar c <> acc) mempty
 -- use stringToHtml or lineToHtml instead, for user strings,
 -- because they understand special chars, like @'<'@.
 primHtml :: String -> Html
-primHtml x | null x    = Html id
-           | otherwise = Html (HtmlString (stringUtf8 x) :)
+primHtml x | null x    = Html []
+           | otherwise = Html [HtmlString (stringUtf8 x)]
 
 -- | Does not process special characters, or check to see if it is empty.
 primHtmlNonEmptyBuilder :: Builder -> Html
-primHtmlNonEmptyBuilder x = Html (HtmlString x :)
+primHtmlNonEmptyBuilder x = Html [HtmlString x]
 
 
 --

--- a/Text/XHtml/Internals.hs
+++ b/Text/XHtml/Internals.hs
@@ -119,7 +119,6 @@ instance HTML Text where
 
 mapDlist :: (a -> b) -> ([a] -> [a]) -> [b] -> [b]
 mapDlist f as = (map f (as []) ++)
-{-# INLINE mapDlist #-}
 
 class ADDATTRS a where
       (!) :: a -> [HtmlAttr] -> a
@@ -170,13 +169,12 @@ fn << arg = fn (toHtml arg)
 
 concatHtml :: (HTML a) => [a] -> Html
 concatHtml = Html . foldr (.) id . map (unHtml . toHtml)
-{-# INLINABLE concatHtml #-}
 
 -- | Create a piece of HTML which is the concatenation
 --   of two things which can be made into HTML.
 (+++) :: (HTML a, HTML b) => a -> b -> Html
 a +++ b = Html (unHtml (toHtml a) . unHtml (toHtml b))
-{-# INLINABLE (+++) #-}
+
 
 -- | An empty piece of HTML.
 noHtml :: Html

--- a/Text/XHtml/Internals.hs
+++ b/Text/XHtml/Internals.hs
@@ -60,8 +60,8 @@ htmlAttrPair (HtmlAttr n v) = (n,v)
 
 
 data Html = Html
-    { unHtml :: [HtmlElement] -> [HtmlElement]
-    , htmlIsEmpty :: Bool
+    { unHtml :: !([HtmlElement] -> [HtmlElement])
+    , htmlIsEmpty :: {-# UNPACK #-} !Bool
     }
 
 getHtmlElements :: Html -> [HtmlElement]

--- a/Text/XHtml/Internals.hs
+++ b/Text/XHtml/Internals.hs
@@ -18,7 +18,6 @@
 module Text.XHtml.Internals
     ( module Text.XHtml.Internals
     , Builder
-    , Seq
     ) where
 
 import qualified Data.Text as Text
@@ -31,9 +30,6 @@ import qualified Data.Monoid as Mon
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
-import qualified Data.Sequence as Seq
-import Data.Sequence (Seq)
-import Data.Foldable (toList)
 
 infixr 2 +++  -- combining Html
 infixr 7 <<   -- nesting Html
@@ -63,10 +59,10 @@ htmlAttrPair :: HtmlAttr -> (Builder,Builder)
 htmlAttrPair (HtmlAttr n v) = (n,v)
 
 
-newtype Html = Html { unHtml :: Seq HtmlElement }
+newtype Html = Html { unHtml :: [HtmlElement] -> [HtmlElement] }
 
-getHtmlElements :: Html -> Seq HtmlElement
-getHtmlElements = unHtml
+getHtmlElements :: Html -> [HtmlElement]
+getHtmlElements html = unHtml html []
 
 builderToString :: Builder -> String
 builderToString =
@@ -88,7 +84,7 @@ instance Show HtmlAttr where
 
 -- | @since 3000.2.2
 instance Sem.Semigroup Html where
-    Html a <> Html b = Html (a <> b)
+    (<>) = (+++)
 
 instance Mon.Monoid Html where
     mempty = noHtml
@@ -101,28 +97,25 @@ class HTML a where
       toHtml     :: a -> Html
       toHtmlFromList :: [a] -> Html
 
-      toHtmlFromList xs = Html (foldr (\x acc -> unHtml (toHtml x) <> acc) mempty xs)
+      toHtmlFromList xs = Html (foldr (\x acc -> unHtml (toHtml x) . acc) id xs)
 
 instance HTML Html where
       toHtml a    = a
 
 instance HTML Char where
       toHtml       a = toHtml [a]
-      toHtmlFromList []  = Html mempty
-      toHtmlFromList str = Html (pure (HtmlString (stringToHtmlString str)))
+      toHtmlFromList []  = Html id
+      toHtmlFromList str = Html (HtmlString (stringToHtmlString str) :)
 
 instance (HTML a) => HTML [a] where
       toHtml xs = toHtmlFromList xs
-
-instance (HTML a) => HTML (Seq a) where
-    toHtml xs = toHtmlFromList (toList xs)
 
 instance HTML a => HTML (Maybe a) where
       toHtml = maybe noHtml toHtml
 
 instance HTML Text where
-    toHtml "" = Html mempty
-    toHtml xs = Html (pure (HtmlString (textToHtmlString xs)))
+    toHtml "" = Html id
+    toHtml xs = Html (HtmlString (textToHtmlString xs) :)
 
 mapDlist :: (a -> b) -> ([a] -> [a]) -> [b] -> [b]
 mapDlist f as = (map f (as []) ++)
@@ -141,7 +134,7 @@ instance (CHANGEATTRS b) => CHANGEATTRS (a -> b) where
       changeAttrs fn f = \ arg -> changeAttrs (fn arg) f
 
 instance ADDATTRS Html where
-    (Html htmls) ! attr = Html (fmap addAttrs htmls)
+    (Html htmls) ! attr = Html (mapDlist addAttrs htmls)
       where
         addAttrs html =
             case html of
@@ -155,7 +148,7 @@ instance ADDATTRS Html where
 
 
 instance CHANGEATTRS Html where
-      changeAttrs (Html htmls) f = Html (fmap addAttrs htmls)
+      changeAttrs (Html htmls) f = Html (mapDlist addAttrs htmls)
         where
               addAttrs (html@(HtmlTag { markupAttrs = attrs }) )
                             = html { markupAttrs = (f . attrs) }
@@ -175,34 +168,37 @@ fn << arg = fn (toHtml arg)
 
 
 concatHtml :: (HTML a) => [a] -> Html
-concatHtml = Html . foldMap (unHtml . toHtml)
+concatHtml = Html . foldr (.) id . map (unHtml . toHtml)
 
 -- | Create a piece of HTML which is the concatenation
 --   of two things which can be made into HTML.
 (+++) :: (HTML a, HTML b) => a -> b -> Html
-a +++ b = toHtml a <> toHtml b
+a +++ b = Html (unHtml (toHtml a) . unHtml (toHtml b))
 
 
 -- | An empty piece of HTML.
 noHtml :: Html
-noHtml = Html mempty
+noHtml = Html id
 
 -- | Checks whether the given piece of HTML is empty. This materializes the
 -- list, so it's not great to do this a bunch.
 isNoHtml :: Html -> Bool
-isNoHtml (Html xs) = Seq.null xs
+isNoHtml (Html xs) = null (xs [])
 
 -- | Constructs an element with a custom name.
 tag :: Builder -- ^ Element name
     -> Html -- ^ Element contents
     -> Html
 tag str htmls =
-    Html $
-        pure HtmlTag
+    Html
+        (
+        HtmlTag
             { markupTag = str
             , markupAttrs = id
             , markupContent = htmls
             }
+        :
+        )
 
 -- | Constructs an element with a custom name, and
 --   without any children.
@@ -253,12 +249,12 @@ textToHtmlString = Text.foldr (\c acc -> fixChar c <> acc) mempty
 -- use stringToHtml or lineToHtml instead, for user strings,
 -- because they understand special chars, like @'<'@.
 primHtml :: String -> Html
-primHtml x | null x    = Html mempty
-           | otherwise = Html (pure (HtmlString (stringUtf8 x)))
+primHtml x | null x    = Html id
+           | otherwise = Html (HtmlString (stringUtf8 x) :)
 
 -- | Does not process special characters, or check to see if it is empty.
 primHtmlNonEmptyBuilder :: Builder -> Html
-primHtmlNonEmptyBuilder x = Html (pure $ HtmlString x)
+primHtmlNonEmptyBuilder x = Html (HtmlString x :)
 
 
 --
@@ -318,7 +314,7 @@ renderHtmlFragment h =
 --   better off using 'showHtmlFragment' or 'renderHtmlFragment'.
 prettyHtmlFragment :: HTML html => html -> String
 prettyHtmlFragment =
-    unlines . toList . foldMap prettyHtml' . getHtmlElements . toHtml
+    unlines . concat . map prettyHtml' . getHtmlElements . toHtml
 
 -- | Show a single HTML element, without adding whitespace.
 showHtml' :: HtmlElement -> Builder
@@ -361,7 +357,7 @@ prettyHtml' (HtmlTag
          [rmNL (renderTag True name (attrs []) "")]
         else
          [rmNL (renderTag False name (attrs []) "")] ++
-          shift (foldMap prettyHtml' (getHtmlElements html)) ++
+          shift (concat (map prettyHtml' (getHtmlElements html))) ++
          [rmNL (renderEndTag name "")]
   where
       shift = map (\x -> "   " ++ x)

--- a/Text/XHtml/Internals.hs
+++ b/Text/XHtml/Internals.hs
@@ -233,24 +233,17 @@ foldHtml f g (HtmlString  str)
 -- | Processing Strings into Html friendly things.
 stringToHtmlString :: String -> Builder
 stringToHtmlString = foldMap fixChar
-    where
-      fixChar '<' = "&lt;"
-      fixChar '>' = "&gt;"
-      fixChar '&' = "&amp;"
-      fixChar '"' = "&quot;"
-      fixChar c | ord c < 0x80 = charUtf8 c
-      fixChar c = mconcat ["&#", intDec (ord c), charUtf8 ';']
+
+fixChar :: Char -> Builder
+fixChar '<' = "&lt;"
+fixChar '>' = "&gt;"
+fixChar '&' = "&amp;"
+fixChar '"' = "&quot;"
+fixChar c | ord c < 0x80 = charUtf8 c
+fixChar c = mconcat ["&#", intDec (ord c), charUtf8 ';']
 
 textToHtmlString :: Text -> Builder
 textToHtmlString = Text.foldr (\c acc -> fixChar c <> acc) mempty
-  where
-    fixChar '<' = "&lt;"
-    fixChar '>' = "&gt;"
-    fixChar '&' = "&amp;"
-    fixChar '"' = "&quot;"
-    fixChar c | ord c < 0x80 = charUtf8 c
-    fixChar c = mconcat ["&#", intDec (ord c), charUtf8 ';']
-
 
 -- | This is not processed for special chars.
 -- use stringToHtml or lineToHtml instead, for user strings,

--- a/Text/XHtml/Internals.hs
+++ b/Text/XHtml/Internals.hs
@@ -59,10 +59,7 @@ htmlAttrPair :: HtmlAttr -> (Builder,Builder)
 htmlAttrPair (HtmlAttr n v) = (n,v)
 
 
-data Html = Html
-    { unHtml :: [HtmlElement] -> [HtmlElement]
-    , htmlIsEmpty :: Bool
-    }
+newtype Html = Html { unHtml :: [HtmlElement] -> [HtmlElement] }
 
 getHtmlElements :: Html -> [HtmlElement]
 getHtmlElements html = unHtml html []
@@ -100,21 +97,15 @@ class HTML a where
       toHtml     :: a -> Html
       toHtmlFromList :: [a] -> Html
 
-      toHtmlFromList [] =
-          Html { unHtml = id, htmlIsEmpty = True }
-      toHtmlFromList xs =
-          Html
-            { htmlIsEmpty = False
-            , unHtml = foldr (\x acc -> unHtml (toHtml x) . acc) id xs
-            }
+      toHtmlFromList xs = Html (foldr (\x acc -> unHtml (toHtml x) . acc) id xs)
 
 instance HTML Html where
       toHtml a    = a
 
 instance HTML Char where
       toHtml       a = toHtml [a]
-      toHtmlFromList []  = Html id True
-      toHtmlFromList str = Html (HtmlString (stringToHtmlString str) :) False
+      toHtmlFromList []  = Html id
+      toHtmlFromList str = Html (HtmlString (stringToHtmlString str) :)
 
 instance (HTML a) => HTML [a] where
       toHtml xs = toHtmlFromList xs
@@ -123,8 +114,8 @@ instance HTML a => HTML (Maybe a) where
       toHtml = maybe noHtml toHtml
 
 instance HTML Text where
-    toHtml "" = Html id True
-    toHtml xs = Html (HtmlString (textToHtmlString xs) :) False
+    toHtml "" = Html id
+    toHtml xs = Html (HtmlString (textToHtmlString xs) :)
 
 mapDlist :: (a -> b) -> ([a] -> [a]) -> [b] -> [b]
 mapDlist f as = (map f (as []) ++)
@@ -143,9 +134,7 @@ instance (CHANGEATTRS b) => CHANGEATTRS (a -> b) where
       changeAttrs fn f = \ arg -> changeAttrs (fn arg) f
 
 instance ADDATTRS Html where
-    (Html htmls isEmpty) ! attr
-        | isEmpty = Html htmls isEmpty
-        | otherwise = Html (mapDlist addAttrs htmls) isEmpty
+    (Html htmls) ! attr = Html (mapDlist addAttrs htmls)
       where
         addAttrs html =
             case html of
@@ -159,9 +148,7 @@ instance ADDATTRS Html where
 
 
 instance CHANGEATTRS Html where
-      changeAttrs (Html htmls isEmpty) f
-        | isEmpty = (Html htmls isEmpty)
-        | otherwise = Html (mapDlist addAttrs htmls) isEmpty
+      changeAttrs (Html htmls) f = Html (mapDlist addAttrs htmls)
         where
               addAttrs (html@(HtmlTag { markupAttrs = attrs }) )
                             = html { markupAttrs = (f . attrs) }
@@ -181,33 +168,22 @@ fn << arg = fn (toHtml arg)
 
 
 concatHtml :: (HTML a) => [a] -> Html
-concatHtml [] = Html id True
-concatHtml xs = Html (foldr (.) id . map (unHtml . toHtml) $ xs) False
+concatHtml = Html . foldr (.) id . map (unHtml . toHtml)
 
 -- | Create a piece of HTML which is the concatenation
 --   of two things which can be made into HTML.
 (+++) :: (HTML a, HTML b) => a -> b -> Html
-a +++ b =
-    case toHtml a of
-        Html k isEmpty
-            | isEmpty ->
-                toHtml b
-            | otherwise ->
-                case toHtml b of
-                    Html k' isEmpty'
-                        | isEmpty' ->
-                            Html k isEmpty
-                        | otherwise ->
-                            Html (k . k') False
+a +++ b = Html (unHtml (toHtml a) . unHtml (toHtml b))
+
 
 -- | An empty piece of HTML.
 noHtml :: Html
-noHtml = Html id True
+noHtml = Html id
 
 -- | Checks whether the given piece of HTML is empty. This materializes the
 -- list, so it's not great to do this a bunch.
 isNoHtml :: Html -> Bool
-isNoHtml (Html _ t) = t
+isNoHtml (Html xs) = null (xs [])
 
 -- | Constructs an element with a custom name.
 tag :: Builder -- ^ Element name
@@ -223,7 +199,6 @@ tag str htmls =
             }
         :
         )
-        False
 
 -- | Constructs an element with a custom name, and
 --   without any children.
@@ -274,12 +249,12 @@ textToHtmlString = Text.foldr (\c acc -> fixChar c <> acc) mempty
 -- use stringToHtml or lineToHtml instead, for user strings,
 -- because they understand special chars, like @'<'@.
 primHtml :: String -> Html
-primHtml x | null x    = Html id True
-           | otherwise = Html (HtmlString (stringUtf8 x) :) False
+primHtml x | null x    = Html id
+           | otherwise = Html (HtmlString (stringUtf8 x) :)
 
 -- | Does not process special characters, or check to see if it is empty.
 primHtmlNonEmptyBuilder :: Builder -> Html
-primHtmlNonEmptyBuilder x = Html (HtmlString x :) False
+primHtmlNonEmptyBuilder x = Html (HtmlString x :)
 
 
 --

--- a/Text/XHtml/Internals.hs
+++ b/Text/XHtml/Internals.hs
@@ -101,21 +101,27 @@ class HTML a where
 
 instance HTML Html where
       toHtml a    = a
+      {-# INLINE toHtml #-}
 
 instance HTML Char where
       toHtml       a = toHtml [a]
+      {-# INLINE toHtml #-}
       toHtmlFromList []  = Html id
       toHtmlFromList str = Html (HtmlString (stringToHtmlString str) :)
+      {-# INLINE toHtmlFromList #-}
 
 instance (HTML a) => HTML [a] where
       toHtml xs = toHtmlFromList xs
+      {-# INLINE toHtml #-}
 
 instance HTML a => HTML (Maybe a) where
       toHtml = maybe noHtml toHtml
+      {-# INLINE toHtml #-}
 
 instance HTML Text where
     toHtml "" = Html id
     toHtml xs = Html (HtmlString (textToHtmlString xs) :)
+    {-# INLINE toHtml #-}
 
 mapDlist :: (a -> b) -> ([a] -> [a]) -> [b] -> [b]
 mapDlist f as = (map f (as []) ++)
@@ -130,11 +136,14 @@ class CHANGEATTRS a where
 
 instance (ADDATTRS b) => ADDATTRS (a -> b) where
       fn ! attr        = \ arg -> fn arg ! attr
+      {-# INLINE (!) #-}
 
 instance (CHANGEATTRS b) => CHANGEATTRS (a -> b) where
       changeAttrs fn f = \ arg -> changeAttrs (fn arg) f
+      {-# INLINE changeAttrs #-}
 
 instance ADDATTRS Html where
+    {-# INLINE (!) #-}
     (Html htmls) ! attr = Html (mapDlist addAttrs htmls)
       where
         addAttrs html =
@@ -149,6 +158,7 @@ instance ADDATTRS Html where
 
 
 instance CHANGEATTRS Html where
+      {-# INLINE changeAttrs #-}
       changeAttrs (Html htmls) f = Html (mapDlist addAttrs htmls)
         where
               addAttrs (html@(HtmlTag { markupAttrs = attrs }) )
@@ -166,6 +176,12 @@ instance CHANGEATTRS Html where
      -> a -- ^ Child
      -> b
 fn << arg = fn (toHtml arg)
+
+{-# SPECIALIZE (<<) :: (Html -> b) -> Html -> b #-}
+{-# SPECIALIZE (<<) :: (Html -> b) -> [Html] -> b #-}
+{-# SPECIALIZE (<<) :: (Html -> b) -> [Html] -> b #-}
+
+{-# INLINABLE (<<) #-}
 
 
 concatHtml :: (HTML a) => [a] -> Html

--- a/Text/XHtml/Internals.hs
+++ b/Text/XHtml/Internals.hs
@@ -140,7 +140,7 @@ instance ADDATTRS Html where
             case html of
                 HtmlTag { markupAttrs = attrs, .. } ->
                     HtmlTag
-                        { markupAttrs = attrs . (++ attr)
+                        { markupAttrs = attrs . (attr ++)
                         , ..
                         }
                 _ ->

--- a/Text/XHtml/Internals.hs
+++ b/Text/XHtml/Internals.hs
@@ -101,27 +101,21 @@ class HTML a where
 
 instance HTML Html where
       toHtml a    = a
-      {-# INLINE toHtml #-}
 
 instance HTML Char where
       toHtml       a = toHtml [a]
-      {-# INLINE toHtml #-}
       toHtmlFromList []  = Html id
       toHtmlFromList str = Html (HtmlString (stringToHtmlString str) :)
-      {-# INLINE toHtmlFromList #-}
 
 instance (HTML a) => HTML [a] where
       toHtml xs = toHtmlFromList xs
-      {-# INLINE toHtml #-}
 
 instance HTML a => HTML (Maybe a) where
       toHtml = maybe noHtml toHtml
-      {-# INLINE toHtml #-}
 
 instance HTML Text where
     toHtml "" = Html id
     toHtml xs = Html (HtmlString (textToHtmlString xs) :)
-    {-# INLINE toHtml #-}
 
 mapDlist :: (a -> b) -> ([a] -> [a]) -> [b] -> [b]
 mapDlist f as = (map f (as []) ++)
@@ -136,14 +130,11 @@ class CHANGEATTRS a where
 
 instance (ADDATTRS b) => ADDATTRS (a -> b) where
       fn ! attr        = \ arg -> fn arg ! attr
-      {-# INLINE (!) #-}
 
 instance (CHANGEATTRS b) => CHANGEATTRS (a -> b) where
       changeAttrs fn f = \ arg -> changeAttrs (fn arg) f
-      {-# INLINE changeAttrs #-}
 
 instance ADDATTRS Html where
-    {-# INLINE (!) #-}
     (Html htmls) ! attr = Html (mapDlist addAttrs htmls)
       where
         addAttrs html =
@@ -158,7 +149,6 @@ instance ADDATTRS Html where
 
 
 instance CHANGEATTRS Html where
-      {-# INLINE changeAttrs #-}
       changeAttrs (Html htmls) f = Html (mapDlist addAttrs htmls)
         where
               addAttrs (html@(HtmlTag { markupAttrs = attrs }) )
@@ -176,12 +166,6 @@ instance CHANGEATTRS Html where
      -> a -- ^ Child
      -> b
 fn << arg = fn (toHtml arg)
-
-{-# SPECIALIZE (<<) :: (Html -> b) -> Html -> b #-}
-{-# SPECIALIZE (<<) :: (Html -> b) -> [Html] -> b #-}
-{-# SPECIALIZE (<<) :: (Html -> b) -> [Html] -> b #-}
-
-{-# INLINABLE (<<) #-}
 
 
 concatHtml :: (HTML a) => [a] -> Html

--- a/Text/XHtml/Internals.hs
+++ b/Text/XHtml/Internals.hs
@@ -60,8 +60,8 @@ htmlAttrPair (HtmlAttr n v) = (n,v)
 
 
 data Html = Html
-    { unHtml :: !([HtmlElement] -> [HtmlElement])
-    , htmlIsEmpty :: {-# UNPACK #-} !Bool
+    { unHtml :: [HtmlElement] -> [HtmlElement]
+    , htmlIsEmpty :: Bool
     }
 
 getHtmlElements :: Html -> [HtmlElement]

--- a/Text/XHtml/Internals.hs
+++ b/Text/XHtml/Internals.hs
@@ -59,10 +59,10 @@ htmlAttrPair :: HtmlAttr -> (Builder,Builder)
 htmlAttrPair (HtmlAttr n v) = (n,v)
 
 
-newtype Html = Html { unHtml :: [HtmlElement] }
+newtype Html = Html { unHtml :: [HtmlElement] -> [HtmlElement] }
 
 getHtmlElements :: Html -> [HtmlElement]
-getHtmlElements html = unHtml html
+getHtmlElements html = unHtml html []
 
 builderToString :: Builder -> String
 builderToString =
@@ -97,15 +97,15 @@ class HTML a where
       toHtml     :: a -> Html
       toHtmlFromList :: [a] -> Html
 
-      toHtmlFromList xs = Html (concatMap (unHtml . toHtml) xs)
+      toHtmlFromList xs = Html (foldr (\x acc -> unHtml (toHtml x) . acc) id xs)
 
 instance HTML Html where
       toHtml a    = a
 
 instance HTML Char where
       toHtml       a = toHtml [a]
-      toHtmlFromList []  = Html []
-      toHtmlFromList str = Html [HtmlString (stringToHtmlString str)]
+      toHtmlFromList []  = Html id
+      toHtmlFromList str = Html (HtmlString (stringToHtmlString str) :)
 
 instance (HTML a) => HTML [a] where
       toHtml xs = toHtmlFromList xs
@@ -114,8 +114,8 @@ instance HTML a => HTML (Maybe a) where
       toHtml = maybe noHtml toHtml
 
 instance HTML Text where
-    toHtml "" = Html []
-    toHtml xs = Html [ HtmlString (textToHtmlString xs) ]
+    toHtml "" = Html id
+    toHtml xs = Html (HtmlString (textToHtmlString xs) :)
 
 mapDlist :: (a -> b) -> ([a] -> [a]) -> [b] -> [b]
 mapDlist f as = (map f (as []) ++)
@@ -134,7 +134,7 @@ instance (CHANGEATTRS b) => CHANGEATTRS (a -> b) where
       changeAttrs fn f = \ arg -> changeAttrs (fn arg) f
 
 instance ADDATTRS Html where
-    (Html htmls) ! attr = Html (map addAttrs htmls)
+    (Html htmls) ! attr = Html (mapDlist addAttrs htmls)
       where
         addAttrs html =
             case html of
@@ -148,7 +148,7 @@ instance ADDATTRS Html where
 
 
 instance CHANGEATTRS Html where
-      changeAttrs (Html htmls) f = Html (map addAttrs htmls)
+      changeAttrs (Html htmls) f = Html (mapDlist addAttrs htmls)
         where
               addAttrs (html@(HtmlTag { markupAttrs = attrs }) )
                             = html { markupAttrs = (f . attrs) }
@@ -168,22 +168,22 @@ fn << arg = fn (toHtml arg)
 
 
 concatHtml :: (HTML a) => [a] -> Html
-concatHtml = Html . concatMap (unHtml . toHtml)
+concatHtml = Html . foldr (.) id . map (unHtml . toHtml)
 
 -- | Create a piece of HTML which is the concatenation
 --   of two things which can be made into HTML.
 (+++) :: (HTML a, HTML b) => a -> b -> Html
-a +++ b = Html (unHtml (toHtml a) <> unHtml (toHtml b))
+a +++ b = Html (unHtml (toHtml a) . unHtml (toHtml b))
 
 
 -- | An empty piece of HTML.
 noHtml :: Html
-noHtml = Html []
+noHtml = Html id
 
 -- | Checks whether the given piece of HTML is empty. This materializes the
 -- list, so it's not great to do this a bunch.
 isNoHtml :: Html -> Bool
-isNoHtml (Html xs) = null xs
+isNoHtml (Html xs) = null (xs [])
 
 -- | Constructs an element with a custom name.
 tag :: Builder -- ^ Element name
@@ -191,12 +191,14 @@ tag :: Builder -- ^ Element name
     -> Html
 tag str htmls =
     Html
-    [ HtmlTag
-        { markupTag = str
-        , markupAttrs = id
-        , markupContent = htmls
-        }
-    ]
+        (
+        HtmlTag
+            { markupTag = str
+            , markupAttrs = id
+            , markupContent = htmls
+            }
+        :
+        )
 
 -- | Constructs an element with a custom name, and
 --   without any children.
@@ -247,12 +249,12 @@ textToHtmlString = Text.foldr (\c acc -> fixChar c <> acc) mempty
 -- use stringToHtml or lineToHtml instead, for user strings,
 -- because they understand special chars, like @'<'@.
 primHtml :: String -> Html
-primHtml x | null x    = Html []
-           | otherwise = Html [HtmlString (stringUtf8 x)]
+primHtml x | null x    = Html id
+           | otherwise = Html (HtmlString (stringUtf8 x) :)
 
 -- | Does not process special characters, or check to see if it is empty.
 primHtmlNonEmptyBuilder :: Builder -> Html
-primHtmlNonEmptyBuilder x = Html [HtmlString x]
+primHtmlNonEmptyBuilder x = Html (HtmlString x :)
 
 
 --

--- a/Text/XHtml/Strict.hs
+++ b/Text/XHtml/Strict.hs
@@ -1,3 +1,5 @@
+{-# language OverloadedStrings #-}
+
 -- | Produces XHTML 1.0 Strict.
 module Text.XHtml.Strict (
      -- * Data types
@@ -5,7 +7,7 @@ module Text.XHtml.Strict (
      -- * Classes
      HTML(..), ADDATTRS(..), CHANGEATTRS(..),
      -- * Primitives and basic combinators
-     (<<), concatHtml, (+++), 
+     (<<), concatHtml, (+++),
      noHtml, isNoHtml, tag, itag,
      htmlAttrPair, emptyAttr, intAttr, strAttr, htmlAttr,
      primHtml, stringToHtmlString,
@@ -24,19 +26,19 @@ import Text.XHtml.Strict.Attributes
 import Text.XHtml.Extras
 
 -- | The @DOCTYPE@ for XHTML 1.0 Strict.
-docType :: String
+docType :: Builder
 docType = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\""
-          ++ " \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">"
+          <> " \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">"
 
 -- | Output the HTML without adding newlines or spaces within the markup.
 --   This should be the most time and space efficient way to
 --   render HTML, though the output is quite unreadable.
-showHtml :: HTML html => html -> String
+showHtml :: HTML html => html -> Builder
 showHtml = showHtmlInternal docType
 
 -- | Outputs indented HTML. Because space matters in
 --   HTML, the output is quite messy.
-renderHtml :: HTML html => html -> String
+renderHtml :: HTML html => html -> Builder
 renderHtml = renderHtmlInternal docType
 
 -- | Outputs indented XHTML. Because space matters in
@@ -44,9 +46,9 @@ renderHtml = renderHtmlInternal docType
 renderHtmlWithLanguage :: HTML html
                        => String -- ^ The code of the "dominant" language of the webpage.
                        -> html -- ^ All the 'Html', including a header.
-                       -> String
+                       -> Builder
 renderHtmlWithLanguage l theHtml =
-    docType ++ "\n" ++ renderHtmlFragment code  ++ "\n"
+    docType <> "\n" <> renderHtmlFragment code  <> "\n"
   where
     code = tag "html" ! [ strAttr "xmlns" "http://www.w3.org/1999/xhtml"
                            , strAttr "lang" l
@@ -54,9 +56,9 @@ renderHtmlWithLanguage l theHtml =
                            ] << theHtml
 
 -- | Outputs indented HTML, with indentation inside elements.
---   This can change the meaning of the HTML document, and 
+--   This can change the meaning of the HTML document, and
 --   is mostly useful for debugging the HTML output.
 --   The implementation is inefficient, and you are normally
 --   better off using 'showHtml' or 'renderHtml'.
 prettyHtml :: HTML html => html -> String
-prettyHtml = prettyHtmlInternal docType
+prettyHtml = prettyHtmlInternal (builderToString docType)

--- a/Text/XHtml/Strict/Attributes.hs
+++ b/Text/XHtml/Strict/Attributes.hs
@@ -1,5 +1,7 @@
 {-# OPTIONS_HADDOCK hide #-}
 
+{-# LANGUAGE OverloadedStrings #-}
+
 module Text.XHtml.Strict.Attributes where
 
 import Text.XHtml.Internals

--- a/Text/XHtml/Strict/Elements.hs
+++ b/Text/XHtml/Strict/Elements.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_HADDOCK hide #-}
 
+{-# LANGUAGE OverloadedStrings #-}
 module Text.XHtml.Strict.Elements where
 
 import Text.XHtml.Internals

--- a/Text/XHtml/Transitional.hs
+++ b/Text/XHtml/Transitional.hs
@@ -1,3 +1,5 @@
+{-# language OverloadedStrings #-}
+
 -- | Produces XHTML 1.0 Transitional.
 module Text.XHtml.Transitional (
      -- * Data types
@@ -5,12 +7,12 @@ module Text.XHtml.Transitional (
      -- * Classes
      HTML(..), ADDATTRS(..), CHANGEATTRS(..),
      -- * Primitives and basic combinators
-     (<<), concatHtml, (+++), 
+     (<<), concatHtml, (+++),
      noHtml, isNoHtml, tag, itag,
      htmlAttrPair, emptyAttr, intAttr, strAttr, htmlAttr,
-     primHtml, 
+     primHtml,
      -- * Rendering
-     showHtml, renderHtml, prettyHtml, 
+     showHtml, renderHtml, prettyHtml,
      showHtmlFragment, renderHtmlFragment, prettyHtmlFragment,
      module Text.XHtml.Strict.Elements,
      module Text.XHtml.Frameset.Elements,
@@ -34,26 +36,26 @@ import Text.XHtml.Transitional.Attributes
 import Text.XHtml.Extras
 
 
-docType :: String
+docType :: Builder
 docType =
-      "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"" ++
+      "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"" <>
      " \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">"
 
 -- | Output the HTML without adding newlines or spaces within the markup.
 --   This should be the most time and space efficient way to
 --   render HTML, though the output is quite unreadable.
-showHtml :: HTML html => html -> String
+showHtml :: HTML html => html -> Builder
 showHtml = showHtmlInternal docType
 
 -- | Outputs indented HTML. Because space matters in
 --   HTML, the output is quite messy.
-renderHtml :: HTML html => html -> String
+renderHtml :: HTML html => html -> Builder
 renderHtml = renderHtmlInternal docType
 
 -- | Outputs indented HTML, with indentation inside elements.
---   This can change the meaning of the HTML document, and 
+--   This can change the meaning of the HTML document, and
 --   is mostly useful for debugging the HTML output.
 --   The implementation is inefficient, and you are normally
 --   better off using 'showHtml' or 'renderHtml'.
 prettyHtml :: HTML html => html -> String
-prettyHtml = prettyHtmlInternal docType
+prettyHtml = prettyHtmlInternal (builderToString docType)

--- a/Text/XHtml/Transitional/Attributes.hs
+++ b/Text/XHtml/Transitional/Attributes.hs
@@ -1,5 +1,7 @@
 {-# OPTIONS_HADDOCK hide #-}
 
+{-# LANGUAGE OverloadedStrings #-}
+
 module Text.XHtml.Transitional.Attributes where
 
 import Text.XHtml.Internals

--- a/Text/XHtml/Transitional/Elements.hs
+++ b/Text/XHtml/Transitional/Elements.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_HADDOCK hide #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Text.XHtml.Transitional.Elements where
 

--- a/xhtml.cabal
+++ b/xhtml.cabal
@@ -24,6 +24,11 @@ Source-repository head
 
 library
     Default-Language: Haskell2010
+    build-depends: 
+        bytestring
+      , text
+      , containers
+
     if impl(ghc >= 7.2)
         Default-Extensions: Safe
 

--- a/xhtml.cabal
+++ b/xhtml.cabal
@@ -1,6 +1,6 @@
 Cabal-version:      >= 1.10
 Name:               xhtml
-Version:            3000.2.2.1
+Version:            3000.3.2.1
 Copyright:          Bjorn Bringert 2004-2006, Andy Gill and the Oregon
                     Graduate Institute of Science and Technology, 1999-2001
 Maintainer:         Chris Dornan <chris@chrisdornan.com>


### PR DESCRIPTION
Fixes #16 

This PR uses `Data.ByteString.Builder` instead of `String` for HTML fragments

Also uses difference lists to avoid the `++` penalty

There's no benchmark on the library, so I can't provide direct results. However, comparing this to my CPS WriterT branch on `haddock`, I'm seeing some nice improvements, particularly for such a local change:

# With just the CPS WriterT

```
!!! ppHtml: finished in 574.35 milliseconds, allocated 1592.523 megabytes
*** Deleting temp dirs:
  26,145,652,864 bytes allocated in the heap
   4,170,952,440 bytes copied during GC
     278,830,600 bytes maximum residency (18 sample(s))
       5,591,544 bytes maximum slop
             621 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      6230 colls,     0 par    2.444s   2.448s     0.0004s    0.0040s
  Gen  1        18 colls,     0 par    1.423s   1.423s     0.0791s    0.2157s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.000s elapsed)
  MUT     time   10.466s  ( 11.403s elapsed)
  GC      time    3.867s  (  3.871s elapsed)
  EXIT    time    0.001s  (  0.006s elapsed)
  Total   time   14.334s  ( 15.280s elapsed)

  Alloc rate    2,498,258,001 bytes per MUT second

  Productivity  73.0% of total user, 74.6% of total elapsed

Documentation created:
/home/matt/Projects/persistent/dist-newstyle/build/x86_64-linux/ghc-9.4.3/persistent-test-2.13.1.3/doc/html/persistent-test/index.html
cabal haddock --haddock-options "-v2 +RTS -s -RTS --optghc=\"-v2\""    16.09s user 1.53s system 98% cpu 17.834 total
```

* HTML allocations: 1,592MB 
* HTML time:        574ms 
* Time:             17.834s
* Mem in use:       621MB
* Allocated:        26.145GB

# Using a `Builder` variant of `xhtml`

```
!!! ppHtml: finished in 298.89 milliseconds, allocated 1578.839 megabytes

  26,199,628,152 bytes allocated in the heap
   3,842,361,072 bytes copied during GC
     204,699,600 bytes maximum residency (17 sample(s))
       5,185,792 bytes maximum slop
             547 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      6139 colls,     0 par    2.358s   2.362s     0.0004s    0.0039s
  Gen  1        17 colls,     0 par    1.168s   1.169s     0.0688s    0.1587s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.000s elapsed)
  MUT     time   10.425s  ( 11.357s elapsed)
  GC      time    3.526s  (  3.531s elapsed)
  EXIT    time    0.001s  (  0.002s elapsed)
  Total   time   13.953s  ( 14.890s elapsed)

  Alloc rate    2,513,036,906 bytes per MUT second

  Productivity  74.7% of total user, 76.3% of total elapsed

Documentation created:
/home/matt/Projects/persistent/dist-newstyle/build/x86_64-linux/ghc-9.4.3/persistent-test-2.13.1.3/doc/html/persistent-test/index.html
cabal haddock --haddock-options "-v2 +RTS -s -RTS --optghc=\"-v2\""    14.38s user 0.89s system 100% cpu 15.236 total
```

* HTML allocations: 1,578MB     (-14MB)     negligible
* HTML time:        299ms       (-275ms)    (48% reduction)
* Mem in use:       547MB       (-74MB)     (12% reduction)

Surprisingly, overall allocations are about the same. I'd have expected the allocations to be much less, since the overhead of a `Builder` is smaller than a `String`.

The reduced memory in use is stable across `haddock` runs. I'm not entirely sure why that's the case, given that allocations are basically unchanged.