### PR TITLE
Lower total allocations

### DIFF
--- a/Text/XHtml/Debug.hs
+++ b/Text/XHtml/Debug.hs
@@ -101,8 +101,8 @@ debugHtml obj = table ! [border 0] <<
               args = if null attrs
                      then ""
                      else "  " <> unwords (map show attrs)
-              hd = xsmallFont << ("<" <> builderToString tag' <> args <> ">")
-              tl = xsmallFont << ("</" <> builderToString tag' <> ">")
+              hd = xsmallFont << ("<" <> lazyByteStringToString tag' <> args <> ">")
+              tl = xsmallFont << ("</" <> lazyByteStringToString tag' <> ">")
 
 bgcolor' :: LText.Text -> HtmlAttr
 bgcolor' c = thestyle ("background-color:" <> c)

--- a/Text/XHtml/Internals.hs
+++ b/Text/XHtml/Internals.hs
@@ -51,7 +51,7 @@ data HtmlElement
       = HtmlString !Builder
         -- ^ ..just..plain..normal..text... but using &copy; and &amb;, etc.
       | HtmlTag {
-              markupTag      :: !Builder,
+              markupTag      :: !BSL.ByteString,
               markupAttrs    :: [HtmlAttr] -> [HtmlAttr],
               markupContent  :: !Html
               }
@@ -73,6 +73,10 @@ getHtmlElements html = unHtml html []
 builderToString :: Builder -> String
 builderToString =
     LText.unpack . LText.decodeUtf8 . toLazyByteString
+
+lazyByteStringToString :: BSL.ByteString -> String
+lazyByteStringToString =
+    LText.unpack . LText.decodeUtf8
 
 --
 -- * Classes
@@ -223,7 +227,7 @@ isNoHtml :: Html -> Bool
 isNoHtml (Html xs) = null (xs [])
 
 -- | Constructs an element with a custom name.
-tag :: Builder -- ^ Element name
+tag :: BSL.ByteString -- ^ Element name
     -> Html -- ^ Element contents
     -> Html
 tag str htmls =
@@ -239,7 +243,7 @@ tag str htmls =
 
 -- | Constructs an element with a custom name, and
 --   without any children.
-itag :: Builder -> Html
+itag :: BSL.ByteString -> Html
 itag str = tag str noHtml
 
 emptyAttr :: Builder -> HtmlAttr
@@ -429,13 +433,16 @@ showHtml'(HtmlTag { markupTag = name,
                     markupContent = html,
                     markupAttrs = attrs })
     = if isValidHtmlITag name && isNoHtml html
-      then renderTag True name (attrs []) ""
-      else renderTag False name (attrs []) ""
+      then renderTag True nameBuilder (attrs []) ""
+      else renderTag False nameBuilder (attrs []) ""
         <> go (getHtmlElements html)
-        <> renderEndTag name ""
+        <> renderEndTag nameBuilder ""
   where
     go [] = mempty
     go (x:xs) = showHtml' x <> go xs
+
+    nameBuilder :: Builder
+    nameBuilder = lazyByteString name
 
 renderHtml' :: Int -> HtmlElement -> Builder
 renderHtml' _ (HtmlString str) = str
@@ -444,10 +451,10 @@ renderHtml' n (HtmlTag
                 markupContent = html,
                 markupAttrs = attrs })
       = if isValidHtmlITag name && isNoHtml html
-        then renderTag True name (attrs []) nl
-        else renderTag False name (attrs []) nl
+        then renderTag True nameBuilder (attrs []) nl
+        else renderTag False nameBuilder (attrs []) nl
           <> foldMap (renderHtml' (n+2)) (getHtmlElements html)
-          <> renderEndTag name nl
+          <> renderEndTag nameBuilder nl
     where
       nl :: Builder
       nl = charUtf8 '\n' <> tabs <> spaces
@@ -464,6 +471,9 @@ renderHtml' n (HtmlTag
           m | m <= 0 -> mempty
           m          -> Sem.stimes m (charUtf8 ' ')
 
+      nameBuilder :: Builder
+      nameBuilder = lazyByteString name
+
 
 prettyHtml' :: HtmlElement -> [String]
 prettyHtml' (HtmlString str) = [builderToString str]
@@ -473,21 +483,24 @@ prettyHtml' (HtmlTag
                 markupAttrs = attrs })
       = if isValidHtmlITag name && isNoHtml html
         then
-         [rmNL (renderTag True name (attrs []) "")]
+         [rmNL (renderTag True nameBuilder (attrs []) "")]
         else
-         [rmNL (renderTag False name (attrs []) "")] ++
+         [rmNL (renderTag False nameBuilder (attrs []) "")] ++
           shift (concatMap prettyHtml' (getHtmlElements html)) ++
-         [rmNL (renderEndTag name "")]
+         [rmNL (renderEndTag nameBuilder "")]
   where
       shift = map ("   " ++)
       rmNL = filter (/= '\n') . builderToString
 
+      nameBuilder :: Builder
+      nameBuilder = lazyByteString name
+
 
 -- | Show a start tag
 renderTag :: Bool       -- ^ 'True' if the empty tag shorthand should be used
-          -> Builder     -- ^ Tag name
+          -> Builder    -- ^ Tag name
           -> [HtmlAttr] -- ^ Attributes
-          -> Builder     -- ^ Whitespace to add after attributes
+          -> Builder    -- ^ Whitespace to add after attributes
           -> Builder
 renderTag empty name attrs nl
       = "<" <> name <> shownAttrs <> nl <> close
@@ -506,8 +519,8 @@ renderEndTag :: Builder -- ^ Tag name
              -> Builder
 renderEndTag name nl = "</" <> name <> nl <> ">"
 
-isValidHtmlITag :: Builder -> Bool
-isValidHtmlITag bldr = toLazyByteString bldr `Set.member` validHtmlITags
+isValidHtmlITag :: BSL.ByteString -> Bool
+isValidHtmlITag bs = bs `Set.member` validHtmlITags
 
 -- | The names of all elements which can be represented using the empty tag
 --   short-hand.

--- a/Text/XHtml/Internals.hs
+++ b/Text/XHtml/Internals.hs
@@ -23,6 +23,7 @@ module Text.XHtml.Internals
 import qualified Data.Text.Lazy as LText
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy.Encoding as LText
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import Data.ByteString.Builder hiding (char7)
 import qualified Data.ByteString.Builder.Prim as P
@@ -140,6 +141,16 @@ instance HTML Text where
 instance HTML LText.Text where
     toHtml "" = Html id
     toHtml xs = Html (HtmlString (lazyTextToHtmlString xs) : )
+    {-# INLINE toHtml #-}
+
+instance HTML BSL.ByteString where
+    toHtml "" = Html id
+    toHtml xs = Html (HtmlString (lazyByteString xs) : )
+    {-# INLINE toHtml #-}
+
+instance HTML BS.ByteString where
+    toHtml "" = Html id
+    toHtml xs = Html (HtmlString (byteString xs) : )
     {-# INLINE toHtml #-}
 
 mapDlist :: (a -> b) -> ([a] -> [a]) -> [b] -> [b]

--- a/xhtml.cabal
+++ b/xhtml.cabal
@@ -1,6 +1,6 @@
 Cabal-version:      >= 1.10
 Name:               xhtml
-Version:            3000.3.0.0
+Version:            3000.4.0.0
 Copyright:          Bjorn Bringert 2004-2006, Andy Gill and the Oregon
                     Graduate Institute of Science and Technology, 1999-2001
 Maintainer:         Chris Dornan <chris@chrisdornan.com>


### PR DESCRIPTION
In #19, I mentioned that the changes lowered max residency but increased total allocations on Haddock. I've now investigated where the increased total allocations are coming from, and this patch now reduces total allocations, while maintaining the reduced max residency.

Before this patch (and some patches on Haddock), the stats on the Agda codebase were:
```
  17,310,445,440 bytes allocated in the heap
   2,697,017,992 bytes copied during GC
     358,309,432 bytes maximum residency (13 sample(s))
       7,586,632 bytes maximum slop
             998 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      3412 colls,     0 par    1.092s   1.105s     0.0003s    0.0032s
  Gen  1        13 colls,     0 par    0.906s   1.007s     0.0775s    0.2389s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.006s  (  0.006s elapsed)
  MUT     time    2.646s  (  3.243s elapsed)
  GC      time    1.998s  (  2.112s elapsed)
  EXIT    time    0.011s  (  0.006s elapsed)
  Total   time    4.661s  (  5.367s elapsed)

  Alloc rate    6,542,622,877 bytes per MUT second

  Productivity  56.8% of total user, 60.4% of total elapsed

        5.42 real         4.84 user         0.45 sys
          1215266816  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              211730  page reclaims
                   1  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                 123  voluntary context switches
                3482  involuntary context switches
            58613513  instructions retired
            13780861  cycles elapsed
             1458752  peak memory footprint
```

The patched stats are now:
```
  12,297,534,536 bytes allocated in the heap
   2,970,492,280 bytes copied during GC
     356,726,824 bytes maximum residency (13 sample(s))
       7,430,184 bytes maximum slop
             991 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0      2883 colls,     0 par    1.183s   1.197s     0.0004s    0.0031s
  Gen  1        13 colls,     0 par    0.902s   0.994s     0.0765s    0.2219s

  TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.007s  (  0.007s elapsed)
  MUT     time    2.385s  (  2.978s elapsed)
  GC      time    2.084s  (  2.191s elapsed)
  EXIT    time    0.012s  (  0.010s elapsed)
  Total   time    4.487s  (  5.185s elapsed)

  Alloc rate    5,157,258,529 bytes per MUT second

  Productivity  53.1% of total user, 57.4% of total elapsed

        5.24 real         4.66 user         0.45 sys
          1207451648  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              211180  page reclaims
                   1  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                 114  voluntary context switches
                3549  involuntary context switches
            58692171  instructions retired
            13607299  cycles elapsed
             1557120  peak memory footprint
```

Much lower total allocations, and even slightly lower max residency and runtime.